### PR TITLE
Use correct prop for checkbox checked value

### DIFF
--- a/src/app/core.cljc
+++ b/src/app/core.cljc
@@ -25,7 +25,7 @@
           status (:task/status e)]
       (p/client
         (ui/checkbox {::dom/id         id
-                      ::dom/checked    (case status :active false, :done true)
+                      ::ui/value       (case status :active false, :done true)
                       ::ui/input-event (p/fn [js-event]
                                          (let [status (-> js-event :target :checked)]
                                            (p/server


### PR DESCRIPTION
Previously the checkbox was effectively an uncontrolled component and would always render unchecked initially even if a todo item status was `:done` in the db.