### PR TITLE
 Readme: Update from -A to -X as is correct in the latest CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # electric-starter-app
 
 ```
-$ clj -A:dev
+$ clj -X:dev
 Starting Electric compiler and server...
 shadow-cljs - server version: 2.20.1 running at http://localhost:9630
 shadow-cljs - nREPL server started on port 9001


### PR DESCRIPTION
With the current clojure CLI version, `:exec-fn` are only run when using the `-X:` invocation.

See https://clojure.org/guides/deps_and_cli#socket_repl for an example

or within clj --help
```
Usage:
  Start a REPL  clj     [clj-opt*] [-Aaliases] [init-opt*]
  Exec fn(s)    clojure [clj-opt*] -X[aliases] a/fn? [kpath v]* kv-map?
  Run tool      clojure [clj-opt*] -T[name|aliases] a/fn [kpath v] kv-map?
  Run main      clojure [clj-opt*] -M[aliases] [init-opt*] [main-opt] [arg*]
  Prepare       clojure [clj-opt*] -P [other exec opts]
```