### PR TITLE
Remove dependency on corfield.build

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,6 +24,5 @@
            {:extra-paths ["src-build"]
             :ns-default build
             :extra-deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}
-                         io.github.seancorfield/build-clj {:git/tag "v0.8.0" :git/sha "9bd8b8a"}
                          thheller/shadow-cljs {:mvn/version "2.20.1"}}
             :jvm-opts ["-Xss2m"]}}}

--- a/src-build/build.clj
+++ b/src-build/build.clj
@@ -1,17 +1,26 @@
 (ns build
   "build electric.jar library artifact and demos"
   (:require [clojure.tools.build.api :as b]
-            [org.corfield.build :as bb]
             [shadow.cljs.devtools.api :as shadow-api] ; so as not to shell out to NPM for shadow
-            [shadow.cljs.devtools.server :as shadow-server]
-            ))
+            [shadow.cljs.devtools.server :as shadow-server]))
 
 (def lib 'com.hyperfiddle/electric)
 (def version (b/git-process {:git-args "describe --tags --long --always --dirty"}))
 (def basis (b/create-basis {:project "deps.edn"}))
 
-(defn clean [opts]
-  (bb/clean opts))
+(defn default-target
+  "Return the default target directory name."
+  {:arglists '([])}
+  ([] (default-target nil))
+  ([target]
+   (or target "target")))
+
+(defn clean
+  "Remove the target folder."
+  [{:keys [target] :as opts}]
+  (println "\nCleaning target...")
+  (b/delete {:path (default-target target)})
+  opts)
 
 (def class-dir "target/classes")
 (defn default-jar-name [{:keys [version] :or {version version}}]


### PR DESCRIPTION
`corfield.build` is deprecated, and the example app only depends on a tiny function from that library anyway. This PR inlines the handful of lines used in `corfield.build` an then removes the dependency from `deps.edn`.

(Note: I staged this PR quickly in the Github UI, and haven't tested it. Please give it a pull and run a build before merging.)