### PR TITLE
Rename hyperfiddle.electric-client/VERSION -> ELECTRIC_USER_VERSION

### DIFF
--- a/src-build/build.clj
+++ b/src-build/build.clj
@@ -30,7 +30,7 @@ on startup)"
   (shadow-api/release :prod {:debug debug,
                              :verbose verbose,
                              :config-merge [{:compiler-options {:optimizations (if optimize :advanced :simple)}
-                                             :closure-defines {'hyperfiddle.electric-client/VERSION version}}]})
+                                             :closure-defines {'hyperfiddle.electric-client/ELECTRIC_USER_VERSION version}}]})
   (shadow-server/stop!))
 
 (defn uberjar [{:keys [jar-name version optimize debug verbose]


### PR DESCRIPTION
[This commit](https://github.com/hyperfiddle/electric/commit/bf842ce7dc3ee084acdaa02f8f69a03a1452026f#diff-11e66f20e43a2bb061b1385a8c9254e2b6a9663a4d0fc8aaadea932b4115ce4bL8-L19) introduced another breaking change: renamed the `hyperfiddle.electric-client/VERSION` to `ELECTRIC_USER_VERSION` and since this var is supposed to be overridden by `clojure-defines` passed to shadow-cljs during build, it needs to be updated here in the electric-starter-app as well.


