### PR TITLE
Fix dev build command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal Electric Clojure app, and instructions on how to integrate it into an 
 
 Dev build:
 
-* Shell: `clj -A:dev -X dev/-main`, or repl: `(dev/-main)`
+* Shell: `clj -A:dev -X user/main`, or repl: `(user/main)`
 * http://localhost:8080
 * Electric root function: [src/electric_starter_app/main.cljc](src/electric_starter_app/main.cljc)
 * Hot code reloading works: edit -> save -> see app reload in browser


### PR DESCRIPTION
I’m guessing that `dev/-main` was replaced with `user/main` at some point, so I updated the readme to fix the dev command.